### PR TITLE
Fix spelling of "utilize" on Deep Links Introduction page

### DIFF
--- a/deep-links/introduction.mdx
+++ b/deep-links/introduction.mdx
@@ -1,6 +1,6 @@
 # Deep Links
 
-The Lunar Client Launcher has support for deep links, the ability to utalise custom URLs starting with `lunarclient://`,
+The Lunar Client Launcher has support for deep links, the ability to utilize custom URLs starting with `lunarclient://`,
 which will interact directly with the Launcher and the user's game. Deep links can be placed on websites, in Discord, or
 anywhere else users have the ability to click on links.
 


### PR DESCRIPTION
Corrects the spelling of "utalise" to "utilize" on the Deep Links Introduction page

https://lunarclient.dev/deep-links/introduction

